### PR TITLE
Include relevant packages for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 requirements = [
     'numpy>=1.10.0',
     'scipy>=0.18.0',
     'xlrd>=1.1.0',
+    'pandas>=0.23',
 ]
 
 setup(name='bayesian_benchmarking',
@@ -14,6 +15,9 @@ setup(name='bayesian_benchmarking',
       license="Apache License 2.0",
       keywords="machine-learning bayesian-methods",
       url="https://github.com/hughsalimbeni/bayesian_benchmarks",
+      python_requires=">=3.5",
+      packages=find_packages(include=["bayesian_benchmarks",
+                                      "bayesian_benchmarks.*"]),
       install_requires=requirements,
       include_package_data=True,
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='bayesian_benchmarking',
       packages=find_packages(include=["bayesian_benchmarks",
                                       "bayesian_benchmarks.*"]),
       install_requires=requirements,
+      package_data={"":["bayesian_benchmarksrc"]},
       include_package_data=True,
       classifiers=[
           'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
This fixes the issue of `pip install .` doing an empty package install (doesn't contain any modules/files), and therefore doesn't work when we are outside the repository. cc. @martinjankowiak

 - Adds pandas requirement and changes the minimum version to python 3.5 because type annotations would throw an error otherwise.
 - Other modules like `models` or `tasks` can be exposed by adding the `__init__.py` file later, if desired.